### PR TITLE
Fix xhr2 URL in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3499,8 +3499,8 @@
       "dev": true
     },
     "xhr2": {
-      "version": "git+ssh://git@github.com/hoodunit/node-xhr2.git#6f65a6557706842b7284191f15ec9afaba270909",
-      "from": "git+ssh://git@github.com/hoodunit/node-xhr2.git#6f65a6557706842b7284191f15ec9afaba270909",
+      "version": "git+https://github.com/hoodunit/node-xhr2.git#6f65a6557706842b7284191f15ec9afaba270909",
+      "from": "git+https://github.com/hoodunit/node-xhr2.git#6f65a6557706842b7284191f15ec9afaba270909",
       "dev": true
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "purescript-psa": "0.7.3",
     "rimraf": "2.5.4",
     "spago": "0.13.1",
-    "xhr2": "git:ssh://git@github.com:hoodunit/node-xhr2.git#6f65a6557706842b7284191f15ec9afaba270909"
+    "xhr2": "https://github.com/hoodunit/node-xhr2.git#6f65a6557706842b7284191f15ec9afaba270909"
   }
 }


### PR DESCRIPTION
I was unable to run tests because xhr2 wasn't installed.  Doing "npm install xhr2" fixed up the reference in package.json, but I decided to use the https URL instead so that a github account wouldn't be required.