### PR TITLE
Update to v0.15.0

### DIFF
--- a/examples/client-github/Main.js
+++ b/examples/client-github/Main.js
@@ -1,8 +1,8 @@
-exports.unsafeParseIso8601DateImpl = function(dateStr) {
+export function unsafeParseIso8601DateImpl(dateStr) {
   return new Date(dateStr)
 } 
 
-exports.readEnvVarImpl = function(nothing) {
+export function readEnvVarImpl(nothing) {
   return function(just) {
     return function(key) {
       return function() {

--- a/packages.dhall
+++ b/packages.dhall
@@ -117,10 +117,27 @@ let additions =
 -------------------------------
 -}
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.14.0-20210324/packages.dhall sha256:b4564d575da6aed1c042ca7936da97c8b7a29473b63f4515f09bb95fae8dddab
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.0-20220510/packages.dhall
+        sha256:0b0d4db1f2f0acd3b37fa53220644ac6f64cf9b5d0226fd097c0593df563d5be
 
 let overrides = {=}
 
-let additions = {=}
+let additions =
+      { simple-json =
+        { dependencies =
+          [ "prelude"
+          , "typelevel-prelude"
+          , "record"
+          , "variant"
+          , "nullable"
+          , "foreign-object"
+          , "foreign"
+          , "exceptions"
+          , "arrays"
+          ]
+        , repo = "https://github.com/justinwoo/purescript-simple-json"
+        , version = "v9.0.0"
+        }
+      }
 
-in upstream // overrides // additions
+in  upstream // overrides // additions

--- a/spago.dhall
+++ b/spago.dhall
@@ -2,6 +2,8 @@
 , dependencies =
     [ "aff"
     , "affjax"
+    , "affjax-node"
+    , "affjax-web"
     , "arrays"
     , "bifunctors"
     , "console"

--- a/src/Payload/Client/Internal/EncodeUri.js
+++ b/src/Payload/Client/Internal/EncodeUri.js
@@ -1,4 +1,4 @@
-exports.encodeUri = function(str) {
+export function encodeUri(str) {
   try {
     return encodeURIComponent(str)
   } catch (e) {

--- a/src/Payload/Client/Queryable.purs
+++ b/src/Payload/Client/Queryable.purs
@@ -27,6 +27,7 @@ import Payload.Client.Options (LogLevel(..), Options, RequestOptions)
 import Payload.Client.Response (ClientError(..), ClientResponse)
 import Payload.ContentType (class HasContentType, getContentType)
 import Payload.Debug (formatJsonString)
+import Payload.Driver (getDriver)
 import Payload.Headers (Headers)
 import Payload.Headers as Headers
 import Payload.Internal.Route (DefaultRouteSpec, Undefined)
@@ -252,7 +253,8 @@ makeRequest {method, url, body, headers, opts, reqOpts} = do
   case opts.logLevel of
     LogDebug -> liftEffect (log (printRequest req))
     _ -> pure unit
-  res <- AX.request req
+  driver <- liftEffect getDriver
+  res <- AX.request driver req
   case opts.logLevel of
     LogDebug -> liftEffect (log (printResponse res))
     _ -> pure unit

--- a/src/Payload/Debug.js
+++ b/src/Payload/Debug.js
@@ -1,8 +1,8 @@
-exports.jsonStringify = function(r) {
+export function jsonStringify(r) {
   return JSON.stringify(r, null, 2)
 }
 
-exports.formatJsonString = function(str) {
+export function formatJsonString(str) {
   try {
     return JSON.stringify(JSON.parse(str), null, 2)
   } catch (e) {

--- a/src/Payload/Driver.js
+++ b/src/Payload/Driver.js
@@ -1,0 +1,12 @@
+export let webEnvironment = !!window;
+export let globalDriver = null;
+
+export function setDriver(driver) {
+    return function() {
+	globalDriver = driver;
+    }
+}
+
+export function getDriver() {
+    return globalDriver;
+}

--- a/src/Payload/Driver.purs
+++ b/src/Payload/Driver.purs
@@ -1,0 +1,22 @@
+module Payload.Driver where
+
+import Prelude
+
+import Affjax (AffjaxDriver)
+import Affjax.Node as Node
+import Affjax.Web as Web
+import Data.Maybe (fromMaybe)
+import Data.Nullable (Nullable, toMaybe)
+import Effect (Effect)
+
+foreign import webEnvironment :: Boolean
+foreign import globalDriver :: Effect (Nullable AffjaxDriver)
+
+-- | Web or node driver for Affjax
+getDriver :: Effect AffjaxDriver
+getDriver = do
+  driver <- toMaybe <$> globalDriver
+  pure $ fromMaybe (if webEnvironment then Web.driver else Node.driver) driver
+
+-- | Set the global Affjax driver to use, in case autodetect fails.
+foreign import setDriver :: AffjaxDriver -> Effect Unit

--- a/src/Payload/Internal/Utils.js
+++ b/src/Payload/Internal/Utils.js
@@ -1,3 +1,3 @@
-exports.toLowerCase = function(str){
+export function toLowerCase(str) {
   return str.toLowerCase()
 }

--- a/src/Payload/Server.js
+++ b/src/Payload/Server.js
@@ -1,4 +1,4 @@
-exports.onError = function(server){
+export function onError(server) {
   return function(cb){
     return function(){
       server.on("error", function(error){

--- a/src/Payload/Server.purs
+++ b/src/Payload/Server.purs
@@ -92,7 +92,7 @@ launch
   => Spec routesSpec
   -> handlers
   -> Effect Unit
-launch routeSpec handlers = Aff.launchAff_ (start_ routeSpec handlers)
+launch routeSpec handlers = Aff.launchAff_ (void $ start_ routeSpec handlers)
 
 -- | Start server with default options and given route spec and handlers (no guards).
 start_

--- a/src/Payload/Server/Cookies.js
+++ b/src/Payload/Server/Cookies.js
@@ -32,8 +32,6 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  * MIT Licensed
  */
 
-'use strict';
-
 /**
  * Module exports.
  * @public
@@ -221,11 +219,11 @@ function tryDecode(str, decode) {
   }
 }
 
-exports.parseWrapper = function (str) {
+export function parseWrapper(str) {
   return parse(str)
 }
 
-exports.serializeImpl = function (name) {
+export function serializeImpl(name) {
   return function(val) {
     return serialize(name, val)
   }

--- a/src/Payload/Server/Handlers.purs
+++ b/src/Payload/Server/Handlers.purs
@@ -21,6 +21,7 @@ import Foreign (readString)
 import Node.FS.Aff as FsAff
 import Node.FS.Stats as Stats
 import Node.FS.Stream (createReadStream)
+import Node.FS.Sync as FsSync
 import Payload.Headers as Headers
 import Payload.ResponseTypes (Failure(..), Response(..), ResponseBody(..))
 import Payload.Server.Internal.MimeTypes as MimeTypes
@@ -39,11 +40,11 @@ data File = File String
 
 instance encodeResponseFile :: EncodeResponse File where
   encodeResponse (Response r@{ body: File path }) = do
-    exists <- lift $ FsAff.exists path
+    exists <- lift $ liftEffect $ FsSync.exists path
     if not exists
       then throwError notFoundError
       else do
-        stat <- lift $ FsAff.stat path
+        stat <- lift $ liftEffect $ FsSync.stat path
         if Stats.isFile stat then do
           fileStream <- lift $ liftEffect $ createReadStream path
           let mimeType = fromMaybe "text/plain" $ MimeTypes.pathToMimeType path

--- a/src/Payload/Server/Internal/MimeTypes.js
+++ b/src/Payload/Server/Internal/MimeTypes.js
@@ -7879,6 +7879,6 @@ function mkExtToTypeMapping(){
 
 var extToTypeMapping = mkExtToTypeMapping()
 
-exports.extensionToMimeTypeImpl = function(extension){
+export function extensionToMimeTypeImpl(extension) {
   return extToTypeMapping[extension]
 }

--- a/src/Payload/Server/Internal/Querystring.js
+++ b/src/Payload/Server/Internal/Querystring.js
@@ -1,5 +1,6 @@
-exports.querystringParse = function(inputStr){
-  var qs = require('querystring');
+import qs from 'querystring';
+
+export function querystringParse(inputStr) {
   var parsed = qs.parse(inputStr);
   for (var prop in parsed) {
     if (Object.prototype.hasOwnProperty.call(parsed, prop)) {

--- a/src/Payload/Server/Internal/ServerResponse.js
+++ b/src/Payload/Server/Internal/ServerResponse.js
@@ -1,4 +1,4 @@
-exports.endResponse_ = function(res){
+export function endResponse_(res) {
   return function(unit){
     return function(cb){
       return function(){

--- a/src/Payload/Server/Internal/ServerResponse.purs
+++ b/src/Payload/Server/Internal/ServerResponse.purs
@@ -65,8 +65,8 @@ writeHeaders res headers = do
 writeStringBody :: HTTP.Response -> String -> Effect Unit
 writeStringBody res str = do
   let out = HTTP.responseAsStream res
-  _ <- Stream.writeString out UTF8 str (pure unit)
-  Stream.end out (pure unit)
+  _ <- Stream.writeString out UTF8 str (const $ pure unit)
+  Stream.end out (const $ pure unit)
 
 writeStreamBody :: HTTP.Response -> UnsafeStream -> Effect Unit
 writeStreamBody res stream = do

--- a/src/Payload/Server/Internal/UrlString.js
+++ b/src/Payload/Server/Internal/UrlString.js
@@ -1,3 +1,3 @@
-exports.unsafeDecodeURIComponent = function(str){
+export function unsafeDecodeURIComponent(str) {
   return decodeURIComponent(str)
 }

--- a/src/Payload/Server/Path.js
+++ b/src/Payload/Server/Path.js
@@ -1,3 +1,5 @@
+import path from 'path';
+
 export function resolve(paths) {
-  return require('path').resolve.apply(this, paths);
+  return path.resolve.apply(this, paths);
 }

--- a/src/Payload/Server/Path.js
+++ b/src/Payload/Server/Path.js
@@ -1,3 +1,3 @@
-exports.resolve = function(paths){
+export function resolve(paths) {
   return require('path').resolve.apply(this, paths);
 }


### PR DESCRIPTION
Update to PureScript v0.15.0
- [update CJS to ESM](https://github.com/purescript/documentation/blob/master/migration-guides/0.15-Migration-Guide.md#how-can-i-update-cjs-to-esm)

_Note: Temporary overrides `simple-json`_

## TODO (Open questions)
There are a couple of errors here related to Affjax, because `purescript-affjax` has some [breaking changes](https://github.com/purescript/documentation/blob/master/migration-guides/0.15-Migration-Guide.md#changes-involving-purescript-affjax). End user are supposed to choose either `affjax-node` or `affjax-web`, but I'm not sure what is the case for this library. I could try to address this if you give me some hints.
